### PR TITLE
Automatic update of Antlr to 3.5.0.2

### DIFF
--- a/WebApplication1/WebApplication1.csproj
+++ b/WebApplication1/WebApplication1.csproj
@@ -46,6 +46,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f">
+      <HintPath>..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.8\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
     </Reference>
@@ -115,10 +119,6 @@
     <Reference Include="WebGrease">
       <Private>True</Private>
       <HintPath>..\packages\WebGrease.1.5.2\lib\WebGrease.dll</HintPath>
-    </Reference>
-    <Reference Include="Antlr3.Runtime">
-      <Private>True</Private>
-      <HintPath>..\packages\Antlr.3.4.1.9004\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/WebApplication1/packages.config
+++ b/WebApplication1/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Antlr" version="3.4.1.9004" targetFramework="net47" />
+  <package id="Antlr" version="3.5.0.2" targetFramework="net47" />
   <package id="bootstrap" version="3.0.0" targetFramework="net47" />
   <package id="jQuery" version="1.10.2" targetFramework="net47" />
   <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net47" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Antlr` to `3.5.0.2` from `3.4.1.9004`
`Antlr 3.5.0.2` was published at `2013-09-12T18:22:34Z`, 4 years and 7 months ago

1 project update:
Updated `WebApplication1\packages.config` to `Antlr` `3.5.0.2` from `3.4.1.9004`

This is an automated update. Merge only if it passes tests

[Antlr 3.5.0.2 on NuGet.org](https://www.nuget.org/packages/Antlr/3.5.0.2)
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
