### PR TITLE
Automatic update of WebGrease to 1.6.0

### DIFF
--- a/WebApplication1/WebApplication1.csproj
+++ b/WebApplication1/WebApplication1.csproj
@@ -112,13 +112,13 @@
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
-    <Reference Include="WebGrease">
-      <Private>True</Private>
-      <HintPath>..\packages\WebGrease.1.5.2\lib\WebGrease.dll</HintPath>
-    </Reference>
     <Reference Include="Antlr3.Runtime">
       <Private>True</Private>
       <HintPath>..\packages\Antlr.3.4.1.9004\lib\Antlr3.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="WebGrease, Version=1.6.5135.21930, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>..\packages\WebGrease.1.6.0\lib\WebGrease.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/WebApplication1/packages.config
+++ b/WebApplication1/packages.config
@@ -25,5 +25,5 @@
   <package id="Modernizr" version="2.6.2" targetFramework="net47" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net47" />
   <package id="Respond" version="1.2.0" targetFramework="net47" />
-  <package id="WebGrease" version="1.5.2" targetFramework="net47" />
+  <package id="WebGrease" version="1.6.0" targetFramework="net47" />
 </packages>


### PR DESCRIPTION
NuKeeper has generated a minor update of `WebGrease` to `1.6.0` from `1.5.2`
`WebGrease 1.6.0` was published at `2014-01-23T22:01:14Z`, 4 years and 3 months ago

1 project update:
Updated `WebApplication1\packages.config` to `WebGrease` `1.6.0` from `1.5.2`

This is an automated update. Merge only if it passes tests

[WebGrease 1.6.0 on NuGet.org](https://www.nuget.org/packages/WebGrease/1.6.0)
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
