### PR TITLE
Automatic update of Newtonsoft.Json to 11.0.2

### DIFF
--- a/WebApplication1.Tests/WebApplication1.Tests.csproj
+++ b/WebApplication1.Tests/WebApplication1.Tests.csproj
@@ -42,6 +42,10 @@
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions">
       <HintPath>..\packages\MSTest.TestFramework.1.1.17\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
@@ -57,9 +61,6 @@
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/WebApplication1.Tests/packages.config
+++ b/WebApplication1.Tests/packages.config
@@ -9,5 +9,5 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net47" />
   <package id="MSTest.TestAdapter" version="1.1.17" targetFramework="net47" />
   <package id="MSTest.TestFramework" version="1.1.17" targetFramework="net47" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net47" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net47" />
 </packages>

--- a/WebApplication1/WebApplication1.csproj
+++ b/WebApplication1/WebApplication1.csproj
@@ -50,6 +50,10 @@
       <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.8\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
@@ -68,9 +72,6 @@
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http">
     </Reference>

--- a/WebApplication1/packages.config
+++ b/WebApplication1/packages.config
@@ -23,7 +23,7 @@
   <package id="Microsoft.Net.Compilers" version="2.4.0" targetFramework="net47" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net47" />
   <package id="Modernizr" version="2.6.2" targetFramework="net47" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net47" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net47" />
   <package id="Respond" version="1.2.0" targetFramework="net47" />
   <package id="WebGrease" version="1.5.2" targetFramework="net47" />
 </packages>


### PR DESCRIPTION
NuKeeper has generated a major update of `Newtonsoft.Json` to `11.0.2` from `6.0.4`
`Newtonsoft.Json 11.0.2` was published at `2018-03-24T20:18:14Z`, 18 days ago

2 project updates:
Updated `WebApplication1\packages.config` to `Newtonsoft.Json` `11.0.2` from `6.0.4`
Updated `WebApplication1.Tests\packages.config` to `Newtonsoft.Json` `11.0.2` from `6.0.4`

This is an automated update. Merge only if it passes tests

[Newtonsoft.Json 11.0.2 on NuGet.org](https://www.nuget.org/packages/Newtonsoft.Json/11.0.2)
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
