### PR TITLE
Automatic update of Microsoft.AspNet.WebApi.Client to 5.2.4

### DIFF
--- a/WebApplication1.Tests/WebApplication1.Tests.csproj
+++ b/WebApplication1.Tests/WebApplication1.Tests.csproj
@@ -47,6 +47,10 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.4\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.Web.Extensions" />
@@ -62,9 +66,6 @@
       <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
-    </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>

--- a/WebApplication1.Tests/packages.config
+++ b/WebApplication1.Tests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net47" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net47" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net47" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.4" targetFramework="net47" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net47" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net47" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net47" />

--- a/WebApplication1/WebApplication1.csproj
+++ b/WebApplication1/WebApplication1.csproj
@@ -53,6 +53,10 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.4\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
@@ -73,9 +77,6 @@
       <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http">
-    </Reference>
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest">
     </Reference>

--- a/WebApplication1/packages.config
+++ b/WebApplication1/packages.config
@@ -14,7 +14,7 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net47" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net47" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net47" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net47" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.4" targetFramework="net47" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net47" />
   <package id="Microsoft.AspNet.WebApi.HelpPage" version="5.2.3" targetFramework="net47" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net47" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.AspNet.WebApi.Client` to `5.2.4` from `5.2.3`
`Microsoft.AspNet.WebApi.Client 5.2.4` was published at `2018-02-12T17:21:00Z`, 2 months ago

2 project updates:
Updated `WebApplication1\packages.config` to `Microsoft.AspNet.WebApi.Client` `5.2.4` from `5.2.3`
Updated `WebApplication1.Tests\packages.config` to `Microsoft.AspNet.WebApi.Client` `5.2.4` from `5.2.3`

This is an automated update. Merge only if it passes tests

[Microsoft.AspNet.WebApi.Client 5.2.4 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNet.WebApi.Client/5.2.4)
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
