### PR TITLE
Automatic update of Microsoft.AspNet.WebApi.Core to 5.2.4

### DIFF
--- a/WebApplication1.Tests/WebApplication1.Tests.csproj
+++ b/WebApplication1.Tests/WebApplication1.Tests.csproj
@@ -47,10 +47,18 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.4\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Abstractions" />
+    <Reference Include="System.Web.Http, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.4\lib\net45\System.Web.Http.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Web.Routing" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
@@ -62,16 +70,10 @@
       <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
-    </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Http.WebHost, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>

--- a/WebApplication1.Tests/packages.config
+++ b/WebApplication1.Tests/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net47" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net47" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net47" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net47" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.4" targetFramework="net47" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.4" targetFramework="net47" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net47" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net47" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net47" />

--- a/WebApplication1.Tests/web.config
+++ b/WebApplication1.Tests/web.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <remove name="OPTIONSVerbHandler" />
+      <remove name="TRACEVerbHandler" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+    </handlers>
+  </system.webServer>
+</configuration>

--- a/WebApplication1/Web.config
+++ b/WebApplication1/Web.config
@@ -18,18 +18,18 @@
     </httpModules>
   </system.web>
   <system.webServer>
-    <handlers>
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
-      <remove name="OPTIONSVerbHandler" />
-      <remove name="TRACEVerbHandler" />
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
-    </handlers>
+    
     <validation validateIntegratedModeConfiguration="false" />
     <modules>
       <remove name="ApplicationInsightsWebTracking" />
       <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" preCondition="managedHandler" />
     </modules>
-  </system.webServer>
+  <handlers>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <remove name="OPTIONSVerbHandler" />
+      <remove name="TRACEVerbHandler" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+    </handlers></system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/WebApplication1/WebApplication1.csproj
+++ b/WebApplication1/WebApplication1.csproj
@@ -53,11 +53,19 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.4\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Web.Http, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.4\lib\net45\System.Web.Http.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
@@ -74,17 +82,11 @@
     </Reference>
     <Reference Include="System.Net.Http">
     </Reference>
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
-    </Reference>
     <Reference Include="System.Net.Http.WebRequest">
     </Reference>
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Http.WebHost, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>

--- a/WebApplication1/packages.config
+++ b/WebApplication1/packages.config
@@ -14,8 +14,8 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net47" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net47" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net47" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net47" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net47" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.4" targetFramework="net47" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.4" targetFramework="net47" />
   <package id="Microsoft.AspNet.WebApi.HelpPage" version="5.2.3" targetFramework="net47" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net47" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net47" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.AspNet.WebApi.Core` to `5.2.4` from `5.2.3`
`Microsoft.AspNet.WebApi.Core 5.2.4` was published at `2018-02-12T17:24:05Z`, 2 months ago

2 project updates:
Updated `WebApplication1\packages.config` to `Microsoft.AspNet.WebApi.Core` `5.2.4` from `5.2.3`
Updated `WebApplication1.Tests\packages.config` to `Microsoft.AspNet.WebApi.Core` `5.2.4` from `5.2.3`

This is an automated update. Merge only if it passes tests

[Microsoft.AspNet.WebApi.Core 5.2.4 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNet.WebApi.Core/5.2.4)
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
