### PR TITLE
Automatic update of Microsoft.ApplicationInsights.Agent.Intercept to 2.4.0

### DIFF
--- a/WebApplication1/WebApplication1.csproj
+++ b/WebApplication1/WebApplication1.csproj
@@ -46,6 +46,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.Agent.Intercept.2.4.0\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.8\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
     </Reference>
@@ -124,9 +128,6 @@
   <ItemGroup>
     <Reference Include="Microsoft.ApplicationInsights">
       <HintPath>..\packages\Microsoft.ApplicationInsights.2.2.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AI.Agent.Intercept">
-      <HintPath>..\packages\Microsoft.ApplicationInsights.Agent.Intercept.2.0.6\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AI.DependencyCollector">
       <HintPath>..\packages\Microsoft.ApplicationInsights.DependencyCollector.2.2.0\lib\net45\Microsoft.AI.DependencyCollector.dll</HintPath>

--- a/WebApplication1/packages.config
+++ b/WebApplication1/packages.config
@@ -4,7 +4,7 @@
   <package id="bootstrap" version="3.0.0" targetFramework="net47" />
   <package id="jQuery" version="1.10.2" targetFramework="net47" />
   <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net47" />
-  <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.0.6" targetFramework="net47" />
+  <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net47" />
   <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.2.0" targetFramework="net47" />
   <package id="Microsoft.ApplicationInsights.PerfCounterCollector" version="2.2.0" targetFramework="net47" />
   <package id="Microsoft.ApplicationInsights.Web" version="2.2.0" targetFramework="net47" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.ApplicationInsights.Agent.Intercept` to `2.4.0` from `2.0.6`
`Microsoft.ApplicationInsights.Agent.Intercept 2.4.0` was published at `2017-06-30T19:04:49Z`, 10 months ago

1 project update:
Updated `WebApplication1\packages.config` to `Microsoft.ApplicationInsights.Agent.Intercept` `2.4.0` from `2.0.6`

This is an automated update. Merge only if it passes tests

[Microsoft.ApplicationInsights.Agent.Intercept 2.4.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.ApplicationInsights.Agent.Intercept/2.4.0)
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
